### PR TITLE
autocommit

### DIFF
--- a/novus-jdbc-core/src/main/scala/com/novus/jdbc/QueryExecutor.scala
+++ b/novus-jdbc-core/src/main/scala/com/novus/jdbc/QueryExecutor.scala
@@ -80,6 +80,7 @@ trait QueryExecutor[DBType] extends StatementExecutor[DBType]{
   final private def executeQuery[T](msg: String, f: Connection => T): T = {
     val now = System.currentTimeMillis
     val con = connection()
+    con setAutoCommit(false)
     try {
       val output = f(con)
       val later = System.currentTimeMillis


### PR DESCRIPTION
This is the missing call to stop the connection from pulling the entirety of the query into memory.